### PR TITLE
Merge updates for django 1.9 from IDEADB fork

### DIFF
--- a/nodes/IDEADB/node/models.py
+++ b/nodes/IDEADB/node/models.py
@@ -75,7 +75,7 @@ class Species(Model):
     chemical_formula = CharField(max_length=40, db_index=True, verbose_name='Chemical Formula', default = '', validators=[validate_chemical_formula])
     mass = PositiveIntegerField(db_index=True, verbose_name='Nominal Mass')
     isotope = BooleanField(verbose_name='Tick, if this is the most abundant isotope', default = True)
-    nuclear_charge = PositiveSmallIntegerField(max_length=3, verbose_name='Number of Protons', blank = True, null = True)
+    nuclear_charge = PositiveSmallIntegerField(verbose_name='Number of Protons', blank = True, null = True)
     inchi = CharField(max_length=300,db_index=True,verbose_name='InChI', blank = True)
     inchikey = CharField(max_length=27, db_index=True, verbose_name='InChI-Key', blank = True)
     cas = CharField(max_length=12,verbose_name='CAS-Number', blank = True, validators = [validate_CAS])
@@ -192,7 +192,7 @@ class Energyscan(Model):
     productiondate = DateField(verbose_name='Production Date')
     comment = TextField(blank = True, max_length = 2000, verbose_name = 'Comment (max. 2000 chars.)')
     energyresolution = DecimalField(max_digits = 4, decimal_places = 3, verbose_name='Energy Resolution of the Experiment in eV')
-    lastmodified = DateTimeField(auto_now = True, auto_now_add = True, default = datetime.datetime.now())
+    lastmodified = DateTimeField(auto_now = True, default = datetime.datetime.now())
     numberofpeaks = IntegerField(blank = True, verbose_name = 'Number of peaks visible (no shoulder structures)')
 
     #define a useful unicode-expression:

--- a/nodes/IDEADB/settings_default.py
+++ b/nodes/IDEADB/settings_default.py
@@ -162,7 +162,7 @@ LOGGING = {
     'handlers': {
         'null': {
             'level':'DEBUG',
-            'class':'django.utils.log.NullHandler',
+            'class':'logging.NullHandler',
         },
         'console':{
             'level':'WARNING',

--- a/vamdctap/bibtextools.py
+++ b/vamdctap/bibtextools.py
@@ -11,7 +11,7 @@ from xml.sax.saxutils import quoteattr
 
 # get the NodeID to put it in the source key
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 DICTS=import_module(settings.NODEPKG+'.dictionaries')
 try: NODEID = DICTS.RETURNABLES['NodeID']
 except: NODEID = 'PleaseFillTheNodeID'


### PR DESCRIPTION
Fixes a bug in bibtextools, where an import failed to due removal of django.utils.importlib (https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9)